### PR TITLE
fabric.mod.json: Allow versions higher than 1.18.x

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.12.6",
-    "minecraft": "1.18.x",
+    "minecraft": ">=1.18",
     "java": ">=17"
   },
   "breaks": {


### PR DESCRIPTION
The mod works even on 1.21.3 despite how old it is so it'd be nice to allow latest versions